### PR TITLE
vapor press no lru

### DIFF
--- a/oil_library/oil_props.py
+++ b/oil_library/oil_props.py
@@ -17,11 +17,6 @@ import copy
 from itertools import groupby, chain
 from future.moves.itertools import zip_longest
 
-try:
-    from functools import lru_cache  # it's built-in on py3
-except ImportError:
-    from backports.functools_lru_cache import lru_cache  # needs backports for py2
-
 import numpy as np
 
 from .models import Oil
@@ -190,7 +185,6 @@ class OilProps(OilWithEstimation):
     def component_types(self):
         return self._sara['type']
 
-    @lru_cache(2)
     def vapor_pressure(self, temp, atmos_pressure=101325.0):
         '''
         water_temp and boiling point units are Kelvin

--- a/oil_library/tests/test_oil_props.py
+++ b/oil_library/tests/test_oil_props.py
@@ -141,6 +141,9 @@ class TestProperties(object):
                       dens for dens in self.s_dens)
 
         assert np.allclose(self.op.mass_fraction.sum(), 1.0)
+    def test_vapor_pressure(self):
+        vp = self.op.vapor_pressure(273.)
+
 
 
 def test_eq():


### PR DESCRIPTION
- tests: vapor pressure fails on py3 because OilProps is not hashable
- oilprops: remove lru cache on vapor_pressure, oilprops is unhashable
